### PR TITLE
fix (login): show shader background on login page

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,7 +4,7 @@ import { LoginForm } from "@/components/login-form";
 
 export default function LoginPage() {
   return (
-    <div className="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
+    <div className="flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
       <div className="flex w-full max-w-sm flex-col gap-6">
         <a href="#" className="flex items-center gap-2 self-center font-medium">
           <div className="bg-primary text-primary-foreground flex size-6 items-center justify-center rounded-md">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,7 +4,7 @@ import { LoginForm } from "@/components/login-form";
 
 export default function LoginPage() {
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
+    <div className="flex h-[calc(100svh-6rem)] flex-col items-center justify-center gap-6 p-6 md:p-10 overflow-hidden">
       <div className="flex w-full max-w-sm flex-col gap-6">
         <a href="#" className="flex items-center gap-2 self-center font-medium">
           <div className="bg-primary text-primary-foreground flex size-6 items-center justify-center rounded-md">

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -12,7 +12,7 @@ export function LoginForm({ className, ...props }: React.ComponentProps<"div">) 
 
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
-      <Card>
+      <Card className="bg-background/50 backdrop-blur-sm border-white/20">
         <CardHeader className="text-center">
           <CardTitle className="text-xl">Howdy!</CardTitle>
           <CardDescription>Login with your Google account</CardDescription>


### PR DESCRIPTION
## Summary
- Remove `bg-muted` from login page wrapper so the animated shader background shows through
- Make the login card translucent with `bg-background/50 backdrop-blur-sm` to blend with the shader

## Test plan
- [ ] Vercel preview shows animated shader background on `/login`
- [ ] Login card is readable with frosted glass effect
- [ ] Google login button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined login page layout with adjusted height calculation and overflow handling
  * Enhanced login form with frosted glass effect and semi-transparent styling for improved visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->